### PR TITLE
docs: don't repeat error list in routes with params

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -244,26 +244,6 @@ https://twitter.com/gr2m/status/697804572623007744)
             }]
         }
 
-+ Response 401 (application/vnd.api+json)
-
-        {
-            errors: [{
-                "status": "401",
-                "title": "Unauthorized",
-                "detail": "Authorization header missing"
-            }]
-        }
-
-+ Response 401 (application/vnd.api+json)
-
-        {
-            errors: [{
-                "status": "401",
-                "title": "Unauthorized",
-                "detail": "Session invalid"
-            }]
-        }
-
 ### Sign Out [DELETE]
 
 + Request
@@ -1185,26 +1165,6 @@ Admins can fetch and manage all user accounts and their profile properties
                     }
                 }]
             }
-
-+ Response 401 (application/vnd.api+json)
-
-        {
-            errors: [{
-                "status": "401",
-                "title": "Unauthorized",
-                "detail": "Authorization header missing"
-            }]
-        }
-
-+ Response 401 (application/vnd.api+json)
-
-        {
-            errors: [{
-                "status": "401",
-                "title": "Unauthorized",
-                "detail": "Session invalid"
-            }]
-        }
 
 ### Update [PATCH]
 


### PR DESCRIPTION
If an error message has been mentioned already to the route without
params, don't repeat it for the route with `?include=` params.

This is for consistency, since in some of the `?include=` routes, the errors are mentioned and in others not.
